### PR TITLE
Add team members to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # sda8-git
+
+Team members: Philipp, Ric, Dena


### PR DESCRIPTION
As discussed, we are listing the team members at the beginning of
the README.

Fixes #2 